### PR TITLE
Adaptive demo fix

### DIFF
--- a/demo/components/a2/adaptive.js
+++ b/demo/components/a2/adaptive.js
@@ -1,8 +1,5 @@
 // Import the Adaptive SDK.
-const Adaptive = require('../../../lib/adaptive');
-// TODO: The above 'require' statement should normally be
-// `require('adaptive-proxy-sdk')` after installing the 'adaptive-proxy-sdk' npm
-// package.
+const Adaptive = require('@ibm-verify/adaptive-proxy');
 
 // Load contents of `.env` into `process.env`.
 require('dotenv').config();
@@ -11,6 +8,6 @@ const config = {
   tenantUrl: process.env.TENANT_URL,
   clientId: process.env.CLIENT_ID,
   clientSecret: process.env.CLIENT_SECRET,
-};
+};r
 
 module.exports = new Adaptive(config);

--- a/demo/components/a2/adaptive.js
+++ b/demo/components/a2/adaptive.js
@@ -8,6 +8,6 @@ const config = {
   tenantUrl: process.env.TENANT_URL,
   clientId: process.env.CLIENT_ID,
   clientSecret: process.env.CLIENT_SECRET,
-};r
+};
 
 module.exports = new Adaptive(config);

--- a/demo/package.json
+++ b/demo/package.json
@@ -11,6 +11,7 @@
   "author": "Adam Dorogi-Kaposi <adam.dorogi-kaposi@ibm.com>",
   "license": "ISC",
   "dependencies": {
+    "@ibm-verify/adaptive-proxy": "^1.7.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "joi": "^14.3.1",


### PR DESCRIPTION
This update allows the demo to function without relying on files in `../../../lib` which are outside the scope of the demo.
This was breaking sample applications downloaded from dev portal application.
