### PR TITLE
Upgrade Express and preserve Artifactory-backed npm resolution

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/
+always-auth=true

--- a/demo/.npmrc
+++ b/demo/.npmrc
@@ -1,0 +1,2 @@
+registry=https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/
+always-auth=true

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -9,10 +9,29 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@ibm-verify/adaptive-proxy": "file:..",
         "dotenv": "^8.2.0",
-        "express": "^4.22.1",
+        "express": "^5.2.1",
         "joi": "^17.13.3",
         "uuid": "^3.4.0"
+      }
+    },
+    "..": {
+      "name": "@ibm-verify/adaptive-proxy",
+      "version": "1.8.0",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "1.15.0",
+        "lru-cache": "^7.10.1",
+        "node-cache": "^5.1.2",
+        "uuid": "^8.3.2"
+      },
+      "devDependencies": {
+        "eslint": "^8.15.0",
+        "eslint-config-google": "^0.14.0",
+        "jsdoc": "^4.0.4",
+        "minami": "^1.2.3",
+        "mocha": "^10.8.2"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -29,6 +48,10 @@
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
+    },
+    "node_modules/@ibm-verify/adaptive-proxy": {
+      "resolved": "..",
+      "link": true
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
@@ -52,45 +75,40 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/accepts/-/accepts-1.3.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Faccepts%2F-%2Faccepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "version": "2.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/accepts/-/accepts-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Faccepts%2F-%2Faccepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.6"
       }
     },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-    },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/body-parser/-/body-parser-1.20.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbody-parser%2F-%2Fbody-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "2.2.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/body-parser/-/body-parser-2.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbody-parser%2F-%2Fbody-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/bytes": {
@@ -132,15 +150,16 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/content-disposition/-/content-disposition-0.5.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcontent-disposition%2F-%2Fcontent-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "version": "1.1.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/content-disposition/-/content-disposition-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcontent-disposition%2F-%2Fcontent-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -162,17 +181,29 @@
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+      "version": "1.2.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/cookie-signature/-/cookie-signature-1.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcookie-signature%2F-%2Fcookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/debug/-/debug-2.6.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.3",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/debug/-/debug-4.4.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/depd": {
@@ -182,16 +213,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/destroy/-/destroy-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdestroy%2F-%2Fdestroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/dotenv": {
@@ -277,80 +298,67 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "5.2.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/express/-/express-5.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fexpress%2F-%2Fexpress-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 18"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/finalhandler": {
-      "version": "1.3.1",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/finalhandler/-/finalhandler-1.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffinalhandler%2F-%2Ffinalhandler-1.3.1.tgz",
-      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "version": "2.1.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/finalhandler/-/finalhandler-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffinalhandler%2F-%2Ffinalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/forwarded": {
@@ -363,12 +371,12 @@
       }
     },
     "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/fresh/-/fresh-0.5.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffresh%2F-%2Ffresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "version": "2.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/fresh/-/fresh-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffresh%2F-%2Ffresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/function-bind": {
@@ -454,31 +462,39 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/http-errors/-/http-errors-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhttp-errors%2F-%2Fhttp-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/http-errors/-/http-errors-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhttp-errors%2F-%2Fhttp-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/iconv-lite/-/iconv-lite-0.4.24.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ficonv-lite%2F-%2Ficonv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/iconv-lite/-/iconv-lite-0.7.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ficonv-lite%2F-%2Ficonv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/inherits": {
@@ -495,6 +511,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/is-promise/-/is-promise-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-promise%2F-%2Fis-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
     },
     "node_modules/joi": {
       "version": "17.13.3",
@@ -519,74 +541,61 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/media-typer/-/media-typer-0.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmedia-typer%2F-%2Fmedia-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "version": "1.1.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/media-typer/-/media-typer-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmedia-typer%2F-%2Fmedia-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/merge-descriptors/-/merge-descriptors-1.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmerge-descriptors%2F-%2Fmerge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "version": "2.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/merge-descriptors/-/merge-descriptors-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmerge-descriptors%2F-%2Fmerge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/mime/-/mime-1.6.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime%2F-%2Fmime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/mime-db/-/mime-db-1.52.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime-db%2F-%2Fmime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/mime-db/-/mime-db-1.54.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime-db%2F-%2Fmime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/mime-types/-/mime-types-2.1.35.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime-types%2F-%2Fmime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/mime-types/-/mime-types-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime-types%2F-%2Fmime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/ms/-/ms-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fms%2F-%2Fms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "version": "2.1.3",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/ms/-/ms-2.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fms%2F-%2Fms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/negotiator/-/negotiator-0.6.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnegotiator%2F-%2Fnegotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "version": "1.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/negotiator/-/negotiator-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnegotiator%2F-%2Fnegotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -616,6 +625,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/once/-/once-1.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fonce%2F-%2Fonce-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/parseurl/-/parseurl-1.3.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fparseurl%2F-%2Fparseurl-1.3.3.tgz",
@@ -626,9 +644,14 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
+      "version": "8.4.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/path-to-regexp/-/path-to-regexp-8.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-to-regexp%2F-%2Fpath-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -644,12 +667,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/qs/-/qs-6.13.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fqs%2F-%2Fqs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/qs/-/qs-6.15.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fqs%2F-%2Fqs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -668,39 +691,35 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/raw-body/-/raw-body-2.5.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fraw-body%2F-%2Fraw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "3.0.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/raw-body/-/raw-body-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fraw-body%2F-%2Fraw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/safe-buffer/-/safe-buffer-5.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafe-buffer%2F-%2Fsafe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/router/-/router-2.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frouter%2F-%2Frouter-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -709,57 +728,48 @@
       "license": "MIT"
     },
     "node_modules/send": {
-      "version": "0.19.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/send/-/send-0.19.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsend%2F-%2Fsend-0.19.0.tgz",
-      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "version": "1.2.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/send/-/send-1.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsend%2F-%2Fsend-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/send/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/encodeurl/-/encodeurl-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fencodeurl%2F-%2Fencodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/ms/-/ms-2.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fms%2F-%2Fms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/serve-static": {
-      "version": "1.16.2",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/serve-static/-/serve-static-1.16.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fserve-static%2F-%2Fserve-static-1.16.2.tgz",
-      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "version": "2.2.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/serve-static/-/serve-static-2.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fserve-static%2F-%2Fserve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.19.0"
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -841,9 +851,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/statuses/-/statuses-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstatuses%2F-%2Fstatuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/statuses/-/statuses-2.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstatuses%2F-%2Fstatuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -859,13 +869,14 @@
       }
     },
     "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/type-is/-/type-is-1.6.18.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-is%2F-%2Ftype-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "version": "2.0.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/type-is/-/type-is-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-is%2F-%2Ftype-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "license": "MIT",
       "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -878,14 +889,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/uuid": {
@@ -903,6 +906,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/wrappy/-/wrappy-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwrappy%2F-%2Fwrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     }
   },
   "dependencies": {
@@ -917,6 +926,20 @@
       "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "requires": {
         "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@ibm-verify/adaptive-proxy": {
+      "version": "file:..",
+      "requires": {
+        "axios": "1.15.0",
+        "eslint": "^8.15.0",
+        "eslint-config-google": "^0.14.0",
+        "jsdoc": "^4.0.4",
+        "lru-cache": "^7.10.1",
+        "minami": "^1.2.3",
+        "mocha": "^10.8.2",
+        "node-cache": "^5.1.2",
+        "uuid": "^8.3.2"
       }
     },
     "@sideway/address": {
@@ -938,36 +961,28 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "accepts": {
-      "version": "1.3.8",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/accepts/-/accepts-1.3.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Faccepts%2F-%2Faccepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "version": "2.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/accepts/-/accepts-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Faccepts%2F-%2Faccepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "requires": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
       }
     },
-    "array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-    },
     "body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/body-parser/-/body-parser-1.20.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbody-parser%2F-%2Fbody-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "2.2.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/body-parser/-/body-parser-2.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbody-parser%2F-%2Fbody-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "requires": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       }
     },
     "bytes": {
@@ -994,12 +1009,9 @@
       }
     },
     "content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/content-disposition/-/content-disposition-0.5.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcontent-disposition%2F-%2Fcontent-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "requires": {
-        "safe-buffer": "5.2.1"
-      }
+      "version": "1.1.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/content-disposition/-/content-disposition-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcontent-disposition%2F-%2Fcontent-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
     },
     "content-type": {
       "version": "1.0.5",
@@ -1012,27 +1024,22 @@
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="
     },
     "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+      "version": "1.2.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/cookie-signature/-/cookie-signature-1.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcookie-signature%2F-%2Fcookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/debug/-/debug-2.6.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.3",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/debug/-/debug-4.4.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
       }
     },
     "depd": {
       "version": "2.0.0",
       "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/depd/-/depd-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdepd%2F-%2Fdepd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
-    },
-    "destroy": {
-      "version": "1.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/destroy/-/destroy-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdestroy%2F-%2Fdestroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
     },
     "dotenv": {
       "version": "8.2.0",
@@ -1088,65 +1095,51 @@
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     },
     "express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "5.2.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/express/-/express-5.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fexpress%2F-%2Fexpress-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "requires": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.14.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-          "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
-          "requires": {
-            "side-channel": "^1.1.0"
-          }
-        }
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       }
     },
     "finalhandler": {
-      "version": "1.3.1",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/finalhandler/-/finalhandler-1.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffinalhandler%2F-%2Ffinalhandler-1.3.1.tgz",
-      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "version": "2.1.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/finalhandler/-/finalhandler-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffinalhandler%2F-%2Ffinalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "requires": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       }
     },
     "forwarded": {
@@ -1155,9 +1148,9 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
     "fresh": {
-      "version": "0.5.2",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/fresh/-/fresh-0.5.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffresh%2F-%2Ffresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+      "version": "2.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/fresh/-/fresh-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffresh%2F-%2Ffresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
     },
     "function-bind": {
       "version": "1.1.2",
@@ -1209,23 +1202,23 @@
       }
     },
     "http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/http-errors/-/http-errors-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhttp-errors%2F-%2Fhttp-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/http-errors/-/http-errors-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhttp-errors%2F-%2Fhttp-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "requires": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       }
     },
     "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/iconv-lite/-/iconv-lite-0.4.24.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ficonv-lite%2F-%2Ficonv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/iconv-lite/-/iconv-lite-0.7.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ficonv-lite%2F-%2Ficonv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
     "inherits": {
@@ -1237,6 +1230,11 @@
       "version": "1.9.1",
       "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/ipaddr.js/-/ipaddr.js-1.9.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fipaddr.js%2F-%2Fipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/is-promise/-/is-promise-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-promise%2F-%2Fis-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "joi": {
       "version": "17.13.3",
@@ -1256,47 +1254,37 @@
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
     },
     "media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/media-typer/-/media-typer-0.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmedia-typer%2F-%2Fmedia-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
+      "version": "1.1.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/media-typer/-/media-typer-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmedia-typer%2F-%2Fmedia-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
     },
     "merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/merge-descriptors/-/merge-descriptors-1.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmerge-descriptors%2F-%2Fmerge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="
-    },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-    },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/mime/-/mime-1.6.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime%2F-%2Fmime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "version": "2.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/merge-descriptors/-/merge-descriptors-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmerge-descriptors%2F-%2Fmerge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
     },
     "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/mime-db/-/mime-db-1.52.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime-db%2F-%2Fmime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+      "version": "1.54.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/mime-db/-/mime-db-1.54.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime-db%2F-%2Fmime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
     },
     "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/mime-types/-/mime-types-2.1.35.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime-types%2F-%2Fmime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/mime-types/-/mime-types-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime-types%2F-%2Fmime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "requires": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/ms/-/ms-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fms%2F-%2Fms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "version": "2.1.3",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/ms/-/ms-2.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fms%2F-%2Fms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/negotiator/-/negotiator-0.6.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnegotiator%2F-%2Fnegotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+      "version": "1.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/negotiator/-/negotiator-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnegotiator%2F-%2Fnegotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
     },
     "object-inspect": {
       "version": "1.13.4",
@@ -1311,15 +1299,23 @@
         "ee-first": "1.1.1"
       }
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/once/-/once-1.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fonce%2F-%2Fonce-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/parseurl/-/parseurl-1.3.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fparseurl%2F-%2Fparseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
+      "version": "8.4.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/path-to-regexp/-/path-to-regexp-8.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-to-regexp%2F-%2Fpath-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -1331,11 +1327,11 @@
       }
     },
     "qs": {
-      "version": "6.13.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/qs/-/qs-6.13.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fqs%2F-%2Fqs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/qs/-/qs-6.15.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fqs%2F-%2Fqs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "requires": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       }
     },
     "range-parser": {
@@ -1344,20 +1340,27 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/raw-body/-/raw-body-2.5.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fraw-body%2F-%2Fraw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "3.0.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/raw-body/-/raw-body-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fraw-body%2F-%2Fraw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "requires": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       }
     },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/safe-buffer/-/safe-buffer-5.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafe-buffer%2F-%2Fsafe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    "router": {
+      "version": "2.2.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/router/-/router-2.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frouter%2F-%2Frouter-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "requires": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -1365,46 +1368,32 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "send": {
-      "version": "0.19.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/send/-/send-0.19.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsend%2F-%2Fsend-0.19.0.tgz",
-      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "version": "1.2.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/send/-/send-1.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsend%2F-%2Fsend-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "requires": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
-      },
-      "dependencies": {
-        "encodeurl": {
-          "version": "1.0.2",
-          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/encodeurl/-/encodeurl-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fencodeurl%2F-%2Fencodeurl-1.0.2.tgz",
-          "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
-        },
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/ms/-/ms-2.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fms%2F-%2Fms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        }
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
       }
     },
     "serve-static": {
-      "version": "1.16.2",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/serve-static/-/serve-static-1.16.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fserve-static%2F-%2Fserve-static-1.16.2.tgz",
-      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "version": "2.2.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/serve-static/-/serve-static-2.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fserve-static%2F-%2Fserve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "requires": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.19.0"
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
       }
     },
     "setprototypeof": {
@@ -1457,9 +1446,9 @@
       }
     },
     "statuses": {
-      "version": "2.0.1",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/statuses/-/statuses-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstatuses%2F-%2Fstatuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+      "version": "2.0.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/statuses/-/statuses-2.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstatuses%2F-%2Fstatuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
     },
     "toidentifier": {
       "version": "1.0.1",
@@ -1467,23 +1456,19 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
     "type-is": {
-      "version": "1.6.18",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/type-is/-/type-is-1.6.18.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-is%2F-%2Ftype-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "version": "2.0.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/type-is/-/type-is-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-is%2F-%2Ftype-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
       }
     },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/unpipe/-/unpipe-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funpipe%2F-%2Funpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
-    },
-    "utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.4.0",
@@ -1494,6 +1479,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/wrappy/-/wrappy-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwrappy%2F-%2Fwrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     }
   }
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -8,11 +8,12 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
-  "author": "Adam Dorogi-Kaposi <adam.dorogi-kaposi@ibm.com>",
+  "author": "IBM Verify <verify@au1.ibm.com>",
   "license": "ISC",
   "dependencies": {
+    "@ibm-verify/adaptive-proxy": "file:..",
     "dotenv": "^8.2.0",
-    "express": "^4.22.1",
+    "express": "^5.2.1",
     "joi": "^17.13.3",
     "uuid": "^3.4.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint-config-google": "^0.14.0",
         "jsdoc": "^4.0.4",
         "minami": "^1.2.3",
-        "mocha": "^10.0.0"
+        "mocha": "^10.8.2"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -233,10 +233,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/ajv/-/ajv-6.14.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fajv%2F-%2Fajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -347,9 +348,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/brace-expansion/-/brace-expansion-1.1.12.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbrace-expansion%2F-%2Fbrace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/brace-expansion/-/brace-expansion-1.1.14.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbrace-expansion%2F-%2Fbrace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -590,9 +591,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/diff/-/diff-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff%2F-%2Fdiff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "5.2.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/diff/-/diff-5.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff%2F-%2Fdiff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1558,9 +1559,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/markdown-it/-/markdown-it-14.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmarkdown-it%2F-%2Fmarkdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/markdown-it/-/markdown-it-14.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmarkdown-it%2F-%2Fmarkdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1722,9 +1723,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/brace-expansion/-/brace-expansion-2.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbrace-expansion%2F-%2Fbrace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/brace-expansion/-/brace-expansion-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbrace-expansion%2F-%2Fbrace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2255,10 +2256,11 @@
       "license": "MIT"
     },
     "node_modules/underscore": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
-      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==",
-      "dev": true
+      "version": "1.13.8",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/underscore/-/underscore-1.13.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funderscore%2F-%2Funderscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -2552,9 +2554,9 @@
       "requires": {}
     },
     "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/ajv/-/ajv-6.14.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fajv%2F-%2Fajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -2640,9 +2642,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/brace-expansion/-/brace-expansion-1.1.12.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbrace-expansion%2F-%2Fbrace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/brace-expansion/-/brace-expansion-1.1.14.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbrace-expansion%2F-%2Fbrace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -2814,9 +2816,9 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "diff": {
-      "version": "5.2.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/diff/-/diff-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff%2F-%2Fdiff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "5.2.2",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/diff/-/diff-5.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff%2F-%2Fdiff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "dev": true
     },
     "dir-glob": {
@@ -3516,9 +3518,9 @@
       "integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ=="
     },
     "markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/markdown-it/-/markdown-it-14.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmarkdown-it%2F-%2Fmarkdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/markdown-it/-/markdown-it-14.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmarkdown-it%2F-%2Fmarkdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1",
@@ -3632,9 +3634,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "2.0.2",
-          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/brace-expansion/-/brace-expansion-2.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbrace-expansion%2F-%2Fbrace-expansion-2.0.2.tgz",
-          "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+          "version": "2.1.0",
+          "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/brace-expansion/-/brace-expansion-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbrace-expansion%2F-%2Fbrace-expansion-2.1.0.tgz",
+          "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
@@ -3985,9 +3987,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
-      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==",
+      "version": "1.13.8",
+      "resolved": "https://na.artifactory.swg-devops.com/artifactory/api/npm/sec-cloud-identity-common-dev-npm-virtual/underscore/-/underscore-1.13.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funderscore%2F-%2Funderscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "docs": "rm -r docs 2>/dev/null; jsdoc -r lib -d docs -t node_modules/minami"
   },
   "keywords": [],
-  "author": "Adam Dorogi-Kaposi <adam.dorogi-kaposi@ibm.com>",
+  "author": "IBM Verify <verify@au1.ibm.com>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/IBM-Verify/adaptive-proxy-sdk-javascript.git"
@@ -26,7 +26,7 @@
     "eslint-config-google": "^0.14.0",
     "jsdoc": "^4.0.4",
     "minami": "^1.2.3",
-    "mocha": "^10.0.0"
+    "mocha": "^10.8.2"
   },
   "bugs": {
     "url": "https://github.com/IBM-Verify/adaptive-proxy-sdk-javascript/issues"


### PR DESCRIPTION

## Summary
This PR updates the demo app dependency tree to resolve the `qs` vulnerability and preserves trusted package resolution through the configured Artifactory registry.

## Changes
- upgrade `demo` from `express@^4.22.1` to `express@^5.2.1`
- refresh `demo/package-lock.json`
- add `@ibm-verify/adaptive-proxy` as a local file dependency in `demo/package.json`
- add root `.npmrc` to force npm resolution through the trusted Artifactory registry
- add `demo/.npmrc` for demo-local npm behavior

## Security impact
- fixes the vulnerable `qs` resolution in the demo dependency tree
- `demo/package-lock.json` now resolves:
  - `express@5.2.1`
  - `body-parser@2.2.2`
  - `qs@6.15.1`

## Notes
- Express 5 requires Node 18+, so the demo now has a higher runtime/tooling requirement
- the demo also requires valid `.env` values (`TENANT_URL`, `CLIENT_ID`, `CLIENT_SECRET`, etc.) to start successfully
- npm is configured to preserve Artifactory-backed `resolved` URLs when lockfiles are updated

## Validation
- updated and pushed branch successfully
- verified dependency resolution in the demo lockfile
- verified the demo progresses past package resolution once the local SDK dependency is wired in